### PR TITLE
PostgreSQL backend for Yapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,28 @@ poetry install
 
 ## Usage
 
-Yapper has a basic interface very similar to Flask.
+Yapper uses environment variables for configuration and automatically selects the appropriate backend based on your environment.
 
-To use `campus-yapper` as an event client listening for events:
+### Environment Variables
+
+Set the following environment variables:
+
+```bash
+export CLIENT_ID="your_unique_client_id"
+export CLIENT_SECRET="your_client_secret"
+export ENV="development"  # development, testing, staging, or production
+```
+
+- **development/testing**: Uses SQLite backend (suitable for local development)
+- **staging/production**: Uses PostgreSQL backend (suitable for production deployments)
+
+### Basic Usage
 
 ```python
 import campus_yapper
 
-# Identify the app using a unique client name string
-yapper = campus_yapper.create('campus.myapp')
+# Create yapper instance (backend determined by ENV variable)
+yapper = campus_yapper.create()
 
 @yapper.on_event('google.forms.submit')
 def on_google_forms_submit(event: Event) -> None:
@@ -38,13 +51,29 @@ def on_google_forms_submit(event: Event) -> None:
     user = event.data['email']
     cca = event.data['cca']
     # Assuming successful form submission adds user to the CCA
-    yap.emit(
+    yapper.emit(
         'campus.circles.user.add',
         data={'user': user, 'circle': cca}
     )
 
 # Begin listening for events and handling them
 yapper.run()
+```
+
+### Backend-Specific Configuration
+
+#### SQLite (Development/Testing)
+```python
+# Optional: specify custom database file
+yapper = campus_yapper.create(db="./my_app.db")
+# Default: uses in-memory database (":memory:")
+```
+
+#### PostgreSQL (Staging/Production)
+```python
+# db_uri parameter is required for staging/production environments
+yapper = campus_yapper.create(db_uri="postgresql://user:pass@host:5432/database")
+# No default value - you must explicitly specify the connection URI
 ```
 
 Dynamic event handler registration is not yet designed, but is on the roadmap.

--- a/campus_yapper/__init__.py
+++ b/campus_yapper/__init__.py
@@ -8,13 +8,61 @@ This package provides the Yapper class for sending and receiving events.
 # See https://docs.python.org/3/tutorial/modules.html#packages for more
 # information.
 
+import os
 from .base import Event, EventHandler, YapperInterface
-from .backends.sqlite import SqliteYapper
+from .backends.sqlite import SQLiteYapper
+from .backends.postgres import PostgreSQLYapper
 
 
-def create(*args, **kwargs) -> YapperInterface:
-    """Factory function to get a Yapper client instance."""
-    return SqliteYapper(*args, **kwargs)
+def create(**kwargs) -> YapperInterface:
+    """Factory function to get a Yapper client instance.
+    
+    Environment variables:
+        CLIENT_ID: Unique identifier for the client (required)
+        CLIENT_SECRET: Client secret for authentication (required) 
+        ENV: Environment type that determines backend ("development", "testing", "staging", "production")
+             - "development" or "testing": SQLiteYapper
+             - "staging" or "production": PostgreSQLYapper
+    
+    Args:
+        **kwargs: Backend-specific arguments:
+            - For SQLite (development/testing): 
+                - db (optional): Database file path, defaults to ":memory:"
+            - For PostgreSQL (staging/production):
+                - db_uri (required): PostgreSQL connection URI
+    
+    Returns:
+        YapperInterface: A backend-specific Yapper instance
+    
+    Raises:
+        ValueError: If CLIENT_ID or CLIENT_SECRET environment variables are not set,
+                   or if db_uri is not provided for PostgreSQL environments
+    """
+    client_id = os.getenv("CLIENT_ID")
+    client_secret = os.getenv("CLIENT_SECRET")
+    env = os.getenv("ENV", "development").lower()
+    
+    if not client_id:
+        raise ValueError("CLIENT_ID environment variable is required")
+    if not client_secret:
+        raise ValueError("CLIENT_SECRET environment variable is required")
+
+    # Determine backend based on environment
+    match env:
+        case "development" | "testing":
+            return SQLiteYapper(client_id, **kwargs)
+        case "staging" | "production":
+            if "db_uri" not in kwargs:
+                raise ValueError(
+                    f"db_uri parameter is required for {env} environment. "
+                    "Please provide a PostgreSQL connection URI."
+                )
+            return PostgreSQLYapper(client_id, **kwargs)
+    
+    raise ValueError(
+        f"Unsupported ENV value: {env}. "
+        "Use 'development', 'testing', 'staging', or 'production'."
+    )
 
 
 # The __all__ variable is used to define the public API of this module.

--- a/campus_yapper/backends/postgres.py
+++ b/campus_yapper/backends/postgres.py
@@ -1,0 +1,205 @@
+"""campus_yapper.backends.postgres
+
+PostgreSQL backend for campus_yapper.
+This implementation is intended for production use.
+"""
+
+from contextlib import contextmanager
+from typing import Generator, TypedDict
+
+import psycopg2
+import psycopg2.extras
+
+from campus_yapper.base import ClientId, Event, EventLabel, EventData, YapperInterface
+
+
+class PostgreSQLResult(TypedDict):
+    """Typed dictionary for PostgreSQL query results."""
+    fetchall: list[dict]
+    lastrowid: int | None
+    rowcount: int
+
+
+def cursor_to_dict(cursor: psycopg2.extras.RealDictCursor) -> PostgreSQLResult:
+    """Extract query results and commonly used attributes from cursor."""
+    # Production implementation should handle large result sets appropriately
+    rows = cursor.fetchall()
+    return {
+        "fetchall": [dict(row) for row in rows],  # Convert RealDictRow to dict
+        "lastrowid": None,  # PostgreSQL doesn't have lastrowid like SQLite
+        "rowcount": cursor.rowcount,
+    }
+
+
+class PostgreSQLYapper(YapperInterface):
+
+    def __init__(
+            self,
+            client_id: ClientId,
+            *,
+            db_uri: str
+    ) -> None:
+        super().__init__(client_id)
+        self.db_uri = db_uri
+
+    @contextmanager
+    def _get_conn(self) -> Generator[psycopg2.extensions.connection, None, None]:
+        """Context manager for PostgreSQL database connection."""
+        conn = psycopg2.connect(self.db_uri)
+        conn.autocommit = True  # Use autocommit mode for performance
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _execute(self, query: str, params: tuple = ()) -> PostgreSQLResult:
+        """Execute a SQL query."""
+        with self._get_conn() as conn:
+            cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            cursor.execute(query, params)
+            return cursor_to_dict(cursor)
+
+    def _executemany(self, query: str, params: list[tuple]) -> PostgreSQLResult:
+        """Execute a SQL query with multiple parameters."""
+        with self._get_conn() as conn:
+            cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            cursor.executemany(query, params)
+            return cursor_to_dict(cursor)
+
+    def _init_db(self) -> None:
+        """Initialize the PostgreSQL database."""
+        self._execute(
+            """CREATE TABLE IF NOT EXISTS events (
+                id BIGSERIAL PRIMARY KEY,
+                label TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );"""
+        )
+        self._execute(
+            """CREATE TABLE IF NOT EXISTS subscriptions (
+                client_id TEXT NOT NULL,
+                label TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (client_id, label)
+            );"""
+        )
+        self._execute(
+            """CREATE TABLE IF NOT EXISTS unread (
+                client_id TEXT NOT NULL,
+                event_id BIGINT NOT NULL,
+                PRIMARY KEY (client_id, event_id),
+                FOREIGN KEY (event_id)
+                    REFERENCES events(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (client_id)
+                    REFERENCES subscriptions(client_id)
+                    ON DELETE CASCADE
+            );"""
+        )
+
+    def emit(self, label: EventLabel, data: EventData | None = None) -> None:
+        """Emit an event to the message broker."""
+        data = data or {}
+        result = self._execute(
+            "INSERT INTO events (label, data) VALUES (%s, %s) RETURNING id",
+            (label, str(data))
+        )
+        event_id = result["fetchall"][0]["id"]
+
+        # Get subscriptions
+        subscriptions = [
+            row["client_id"] for row in self._execute(
+                "SELECT client_id FROM subscriptions WHERE label = %s",
+                (label,)
+            )["fetchall"]
+        ]
+
+        # Notify subscriptions
+        if subscriptions:
+            self._executemany(
+                "INSERT INTO unread (client_id, event_id) VALUES (%s, %s)",
+                [(client_id, event_id) for client_id in subscriptions]
+            )
+
+    def subscribe(self, label: EventLabel) -> None:
+        """Subscribe to an event label."""
+        self._execute(
+            """INSERT INTO subscriptions (client_id, label)
+              VALUES (%s, %s)
+              ON CONFLICT (client_id, label) DO NOTHING""",
+            (self.client_id, label)
+        )
+
+    def unsubscribe(self, label: EventLabel) -> None:
+        """Unsubscribe from an event label.
+
+        A label value of * will unsubscribe from all labels.
+        This is not set as a default value for safety reasons.
+        """
+        if label == "*":
+            self._execute(
+                "DELETE FROM subscriptions WHERE client_id = %s",
+                (self.client_id,)
+            )
+        else:
+            self._execute(
+                "DELETE FROM subscriptions WHERE client_id = %s AND label = %s",
+                (self.client_id, label)
+            )
+        self._sweep()  # Clean up old events
+
+    def _clear_unread(self) -> None:
+        """Clear unread events for this client.
+
+        This is performed as part of other operations, and is seldom called on
+        its own.
+        """
+        self._execute(
+            "DELETE FROM unread WHERE client_id = %s",
+            (self.client_id,)
+        )
+
+    def listen(self) -> list[Event]:
+        """Listen for events from the message broker."""
+        # NOTE: There is a tiny window between the two queries where
+        # events could be emitted but not collected before being cleared.
+        # In a production system, this should use transactions or
+        # a more sophisticated event delivery mechanism.
+
+        # Get and clear unread events
+        result = self._execute(
+            "SELECT events.label, events.data FROM events "
+            "JOIN unread ON events.id = unread.event_id "
+            "WHERE unread.client_id = %s",
+            (self.client_id,)
+        )
+        events = result["fetchall"]
+
+        # Clear unread events
+        self._clear_unread()
+
+        # Return events
+        return [
+            Event(row["label"], row["data"])
+            for row in events
+        ]
+
+    def _sweep(self) -> None:
+        """Clear old events without subscriptions."""
+        self._execute(
+            "DELETE FROM events WHERE id NOT IN "
+            "(SELECT DISTINCT event_id FROM unread)"
+        )
+
+    def start(self) -> None:
+        """Start the Yapper instance."""
+        self._init_db()
+        super().start()
+
+    def stop(self) -> None:
+        """Stop the Yapper instance."""
+        self.listen()  # also clears unread
+        self.unsubscribe("*")
+        self._sweep()
+        super().stop()

--- a/campus_yapper/backends/postgres.py
+++ b/campus_yapper/backends/postgres.py
@@ -87,13 +87,14 @@ class PostgreSQLYapper(YapperInterface):
         self._execute(
             """CREATE TABLE IF NOT EXISTS unread (
                 client_id TEXT NOT NULL,
+                label TEXT NOT NULL,
                 event_id BIGINT NOT NULL,
-                PRIMARY KEY (client_id, event_id),
+                PRIMARY KEY (client_id, label, event_id),
                 FOREIGN KEY (event_id)
                     REFERENCES events(id)
                     ON DELETE CASCADE,
-                FOREIGN KEY (client_id)
-                    REFERENCES subscriptions(client_id)
+                FOREIGN KEY (client_id, label)
+                    REFERENCES subscriptions(client_id, label)
                     ON DELETE CASCADE
             );"""
         )

--- a/campus_yapper/backends/sqlite.py
+++ b/campus_yapper/backends/sqlite.py
@@ -4,10 +4,12 @@ SQLite backend for campus_yapper.
 This implementation is for local testing purposes only.
 It is not intended for production use.
 """
-from campus_yapper.base import ClientId, Event, EventLabel, EventData, YapperInterface
-import sqlite3
+
 from typing import Any, Generator, TypedDict
 from contextlib import contextmanager
+import sqlite3
+
+from campus_yapper.base import ClientId, Event, EventLabel, EventData, YapperInterface
 
 
 class SQLiteResult(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "psycopg2 (>=2.9.10,<3.0.0)"
+    "psycopg2-binary>=2.9.10,<3.0.0"
 ]
 
 

--- a/tests/test_env_factory.py
+++ b/tests/test_env_factory.py
@@ -1,0 +1,140 @@
+"""Tests for environment-based factory function."""
+import os
+import unittest
+from unittest.mock import patch
+import campus_yapper
+from campus_yapper.backends.sqlite import SQLiteYapper
+from campus_yapper.backends.postgres import PostgreSQLYapper
+
+
+class TestEnvFactory(unittest.TestCase):
+    """Test cases for environment-based factory function."""
+
+    def setUp(self):
+        """Set up test environment variables."""
+        # Store original values to restore later
+        self.original_env = {
+            'CLIENT_ID': os.environ.get('CLIENT_ID'),
+            'CLIENT_SECRET': os.environ.get('CLIENT_SECRET'),
+            'ENV': os.environ.get('ENV')
+        }
+
+    def tearDown(self):
+        """Restore original environment variables."""
+        for key, value in self.original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_create_requires_client_id(self):
+        """Test that CLIENT_ID environment variable is required."""
+        # Clear environment variables
+        os.environ.pop("CLIENT_ID", None)
+        os.environ.pop("CLIENT_SECRET", None)
+        
+        with self.assertRaises(ValueError) as context:
+            campus_yapper.create()
+        self.assertIn("CLIENT_ID environment variable is required", str(context.exception))
+
+    def test_create_requires_client_secret(self):
+        """Test that CLIENT_SECRET environment variable is required."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ.pop("CLIENT_SECRET", None)
+        
+        with self.assertRaises(ValueError) as context:
+            campus_yapper.create()
+        self.assertIn("CLIENT_SECRET environment variable is required", str(context.exception))
+
+    def test_create_development_env(self):
+        """Test that development environment uses SQLite."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "development"
+        
+        yapper = campus_yapper.create()
+        self.assertIsInstance(yapper, SQLiteYapper)
+        self.assertEqual(yapper.client_id, "test_client")
+
+    def test_create_testing_env(self):
+        """Test that testing environment uses SQLite."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "testing"
+        
+        yapper = campus_yapper.create()
+        self.assertIsInstance(yapper, SQLiteYapper)
+
+    @patch('campus_yapper.backends.postgres.psycopg2')
+    def test_create_staging_env(self, mock_psycopg2):
+        """Test that staging environment uses PostgreSQL."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "staging"
+        
+        yapper = campus_yapper.create(db_uri="postgresql://test@localhost:5432/test_db")
+        self.assertIsInstance(yapper, PostgreSQLYapper)
+
+    @patch('campus_yapper.backends.postgres.psycopg2')
+    def test_create_production_env(self, mock_psycopg2):
+        """Test that production environment uses PostgreSQL."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "production"
+        
+        yapper = campus_yapper.create(db_uri="postgresql://test@localhost:5432/test_db")
+        self.assertIsInstance(yapper, PostgreSQLYapper)
+
+    def test_create_default_env(self):
+        """Test that missing ENV defaults to development (SQLite)."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ.pop("ENV", None)
+        
+        yapper = campus_yapper.create()
+        self.assertIsInstance(yapper, SQLiteYapper)
+
+    def test_create_invalid_env(self):
+        """Test that invalid ENV raises ValueError."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "invalid"
+        
+        with self.assertRaises(ValueError) as context:
+            campus_yapper.create()
+        self.assertIn("Unsupported ENV value: invalid", str(context.exception))
+
+    def test_create_with_kwargs(self):
+        """Test that kwargs are passed to backend constructors."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "development"
+        
+        yapper = campus_yapper.create(db="./test.db")
+        self.assertIsInstance(yapper, SQLiteYapper)
+        # Check that the database path was set correctly
+        self.assertEqual(yapper.db_uri, "./test.db")  # type: ignore
+
+    def test_create_staging_env_missing_db_uri(self):
+        """Test that staging environment requires db_uri parameter."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "staging"
+        
+        with self.assertRaises(ValueError) as context:
+            campus_yapper.create()
+        self.assertIn("db_uri parameter is required for staging environment", str(context.exception))
+
+    def test_create_production_env_missing_db_uri(self):
+        """Test that production environment requires db_uri parameter."""
+        os.environ["CLIENT_ID"] = "test_client"
+        os.environ["CLIENT_SECRET"] = "test_secret"
+        os.environ["ENV"] = "production"
+        
+        with self.assertRaises(ValueError) as context:
+            campus_yapper.create()
+        self.assertIn("db_uri parameter is required for production environment", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,76 @@
+"""Tests for the PostgreSQL backend."""
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from campus_yapper.backends.postgres import PostgreSQLYapper
+from campus_yapper.base import Event
+
+
+@pytest.fixture
+def mock_psycopg2():
+    """Mock psycopg2 for testing without requiring a real database."""
+    with patch('campus_yapper.backends.postgres.psycopg2') as mock:
+        # Mock connection
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.rowcount = 0
+        mock_cursor.lastrowid = None
+        mock_conn.cursor.return_value = mock_cursor
+        mock.connect.return_value = mock_conn
+        
+        yield mock
+
+
+def test_postgres_yapper_init():
+    """Test PostgreSQLYapper initialization."""
+    yapper = PostgreSQLYapper(
+        "test_client",
+        db_uri="postgresql://testuser:testpass@testhost:5432/testdb"
+    )
+    
+    assert yapper.client_id == "test_client"
+    assert yapper.db_uri == "postgresql://testuser:testpass@testhost:5432/testdb"
+
+
+def test_postgres_yapper_emit(mock_psycopg2):
+    """Test emitting an event."""
+    yapper = PostgreSQLYapper("test_client")
+    
+    # Mock the return value for the INSERT ... RETURNING query
+    mock_cursor = mock_psycopg2.connect.return_value.cursor.return_value
+    mock_cursor.fetchall.return_value = [{"id": 1}]
+    
+    yapper.emit("test_label", {"key": "value"})
+    
+    # Verify that execute was called (at least twice - once for insert, once for select subscriptions)
+    assert mock_cursor.execute.call_count >= 2
+
+
+def test_postgres_yapper_subscribe(mock_psycopg2):
+    """Test subscribing to an event label."""
+    yapper = PostgreSQLYapper("test_client")
+    
+    yapper.subscribe("test_label")
+    
+    mock_cursor = mock_psycopg2.connect.return_value.cursor.return_value
+    mock_cursor.execute.assert_called()
+
+
+def test_postgres_yapper_listen(mock_psycopg2):
+    """Test listening for events."""
+    yapper = PostgreSQLYapper("test_client")
+    
+    # Mock the return value for the SELECT query
+    mock_cursor = mock_psycopg2.connect.return_value.cursor.return_value
+    mock_cursor.fetchall.return_value = [
+        {"label": "test_label", "data": "{'key': 'value'}"}
+    ]
+    
+    events = yapper.listen()
+    
+    assert len(events) == 1
+    assert events[0].label == "test_label"
+    assert events[0].data == "{'key': 'value'}"
+    
+    # Verify that execute was called at least twice (select events + clear unread)
+    assert mock_cursor.execute.call_count >= 2


### PR DESCRIPTION
This PR implements the PostgreSQL backend for yapper. It also updates the factory function to return a SQLiteYapper for development and testing, and a PostgreSQLYapper for staging and production.

Fix #7, #8